### PR TITLE
replace all hard-coded dotfiles locations

### DIFF
--- a/git/hooks/recent.post-merge
+++ b/git/hooks/recent.post-merge
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo ""
 echo ""
-echo -e "\033[1m RECENT COMMITS \033[0m"
+echo -e "\\033[1m RECENT COMMITS \\033[0m"
 git --no-pager log -n5 --graph --pretty=format:'%Cred%h%Creset %an: %s - %Creset %C(yellow)%d%Creset %Cgreen(%cr)%Creset' --abbrev-commit --date=relative
 echo ""
 echo ""

--- a/git/templates/hooks/run-hooks.sh
+++ b/git/templates/hooks/run-hooks.sh
@@ -1,17 +1,15 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 EXIT_CODE=0
 
-repo=$( git rev-parse --show-toplevel )
-hook_type=$( basename $0 )
-hooks=~/.dotfiles/git/hooks
-
+hook_type="$(basename "$0")"
+hooks="$DOTFILES/git/hooks"
 shopt -s nullglob
 for hook in $hooks/*.$hook_type; do
 	echo ""
 	echo "${COLOR_LIGHTPURPLE}Executing ${hook}${COLOR_NONE}"
 	${hook}
-	EXIT_CODE=$((${EXIT_CODE} + $?))
+    EXIT_CODE=$((EXIT_CODE + $?))
 done
 
 if [[ ${EXIT_CODE} -ne 0 ]]; then
@@ -19,4 +17,4 @@ if [[ ${EXIT_CODE} -ne 0 ]]; then
 	echo "${COLOR_RED}Commit Failed.${COLOR_NONE}"
 fi
 
-exit $((${EXIT_CODE}))
+exit $EXIT_CODE

--- a/install/backup.sh
+++ b/install/backup.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-# Backup files that are provided by the dotfiles into a ~/dotfiles-backup directory
+DOTFILES=$(realpath "$(realpath "$(dirname "$0")")/..")
 
-DOTFILES=$HOME/.dotfiles
+# Backup files that are provided by the dotfiles into a ~/dotfiles-backup directory
 BACKUP_DIR=$HOME/dotfiles-backup
 
 set -e # Exit immediately if a command exits with a non-zero status.

--- a/install/git.sh
+++ b/install/git.sh
@@ -2,6 +2,8 @@
 
 printf "Setting up Git...\\n\\n"
 
+DOTFILES=$(realpath "$(realpath "$(dirname "$0")")/..")
+
 defaultName=$( git config --global user.name )
 defaultEmail=$( git config --global user.email )
 defaultGithub=$( git config --global github.user )
@@ -9,6 +11,8 @@ defaultGithub=$( git config --global github.user )
 read -rp "Name [$defaultName] " name
 read -rp "Email [$defaultEmail] " email
 read -rp "Github username [$defaultGithub] " github
+
+git config --global init.templatedir = "$DOTFILES/git/templates"
 
 git config --global user.name "${name:-$defaultName}"
 git config --global user.email "${email:-$defaultEmail}"

--- a/install/link.sh
+++ b/install/link.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DOTFILES=$HOME/code/dotfiles
+DOTFILES=$(realpath "$(realpath "$(dirname "$0")")/..")
 
 echo -e "\\nCreating symlinks"
 echo "=============================="

--- a/install/nginx.sh
+++ b/install/nginx.sh
@@ -7,8 +7,6 @@ echo "=============================="
 # nginx setup
 ######################################################
 
-DOTFILES="$HOME/.dotfiles"
-
 # first, make sure apache is off
 sudo launchctl unload -w /System/Library/LaunchDaemons/org.apache.httpd.plist
 

--- a/tmux/theme.sh
+++ b/tmux/theme.sh
@@ -47,13 +47,13 @@ set-option -g display-panes-colour $tm_color_inactive
 # clock
 set-window-option -g clock-mode-colour $tm_color_active
 
-# tm_tunes="#[fg=$tm_color_music]#(osascript ~/.dotfiles/applescripts/tunes.scpt | cut -c 1-50)"
-tm_tunes="#[fg=$tm_color_music]#(osascript -l JavaScript ~/.dotfiles/applescripts/tunes.js)"
-tm_battery="#(~/.dotfiles/bin/battery_indicator.sh)"
+# tm_tunes="#[fg=$tm_color_music]#(osascript $DOTFILES/applescripts/tunes.scpt | cut -c 1-50)"
+tm_tunes="#[fg=$tm_color_music]#(osascript -l JavaScript $DOTFILES/applescripts/tunes.js)"
+# tm_battery="#($DOTFILES/bin/battery_indicator.sh)"
 
 tm_date="#[fg=$tm_color_inactive] %R %d %b"
 tm_host="#[fg=$tm_color_feature,bold]#h"
 tm_session_name="#[fg=$tm_color_feature,bold]#S"
 
-set -g status-left $tm_session_name' '
-set -g status-right $tm_tunes' '$tm_date' '$tm_host
+set -g status-left "$tm_session_name "
+set -g status-right "$tm_tunes $tm_date $tm_host"

--- a/tmux/tmux.conf.symlink
+++ b/tmux/tmux.conf.symlink
@@ -23,6 +23,10 @@ bind-key a send-prefix
 setw -g monitor-activity off
 set -g visual-activity off
 
+# Add path to DOTFILES as an environment variable that
+# is reachable by the tmux config scripts
+set-environment -g DOTFILES "$DOTFILES"
+
 # Rather than constraining window size to the maximum size of any client
 # connected to the *session*, constrain window size to the maximum size of any
 # client connected to *that window*. Much more reasonable.

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -1,4 +1,5 @@
-export DOTFILES=$HOME/.dotfiles
+# export DOTFILES="${0:a:h}"
+export DOTFILES="$(realpath $(dirname $(realpath ~/.zshrc))/..)"
 export ZSH=$DOTFILES/zsh
 
 command_exists() {


### PR DESCRIPTION
Replace dotfiles hard-coded path (~/.dotfiles) with dynamically
generated paths based on where the repo is actually located. Fixes #78 