### PR TITLE
Fix path typo to dotfiles directory

### DIFF
--- a/install/link.sh
+++ b/install/link.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DOTFILES=$HOME/code/dotfiles
+DOTFILES=$HOME/.dotfiles
 
 echo -e "\\nCreating symlinks"
 echo "=============================="


### PR DESCRIPTION
Tiny fix to the path given in links.sh for the dotfiles.