### PR TITLE
Make tmux.conf compatible with Linux

### DIFF
--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -1,9 +1,9 @@
 # gitconfig
 [user]
-    name = Nick Nisi
-    email = nick@nisi.org
+	name = Arturo
+	email = arturojosejr@gmail.com
 [github]
-    user = nicknisi
+	user = ajr-dev
 [init]
     templatedir = ~/.dotfiles/git/templates
 [alias]
@@ -156,7 +156,7 @@
     extendRegexp = true
     lineNumber = true
 [credential]
-	helper = osxkeychain
+	helper = store
 [difftool "Kaleidoscope"]
 	cmd = ksdiff --partial-changeset --relative-path \"$MERGED\" -- \"$LOCAL\" \"$REMOTE\"
 [mergetool "Kaleidoscope"]

--- a/install/git.sh
+++ b/install/git.sh
@@ -17,8 +17,9 @@ git config --global github.user "${github:-$defaultGithub}"
 if [[ "$( uname )" == "Darwin" ]]; then
     git config --global credential.helper "osxkeychain"
 else
-    read -rn 1 -p "Save user and password to an unencrypted file to avoid writing? [y/N] " save
-    if [[ $save =~ ^([Yy])$ ]]; then
+    read -p "Save user and password to an unencrypted file to avoid writing? "
+    printf '\n'
+    if [[ $REPLY =~ ^[Yy] ]]; then
         git config --global credential.helper "store"
     else
         git config --global credential.helper "cache --timeout 3600"

--- a/tmux/tmux.conf.symlink
+++ b/tmux/tmux.conf.symlink
@@ -1,4 +1,5 @@
-set -g default-command "login-shell"
+if-shell "uname | grep -q Darwin" \
+    'set -g default-command "login-shell"'
 
 # tmux display things in 256 colors
 set -g default-terminal "tmux-256color"
@@ -86,11 +87,12 @@ bind Escape copy-mode
 unbind p
 bind p paste-buffer
 bind -Tcopy-mode-vi 'v' send -X begin-selection
-bind -Tcopy-mode-vi 'y' send -X copy-pipe-and-cancel "tmux save-buffer - | reattach-to-user-namespace pbcopy"
 
-# Buffers to/from Mac clipboard, yay tmux book from pragprog
-bind C-c run "tmux save-buffer - | reattach-to-user-namespace pbcopy"
-bind C-v run "tmux set-buffer $(reattach-to-user-namespace pbpaste); tmux paste-buffer"
+if-shell "uname | grep -q Darwin" " \
+    bind-key -T copy-mode-vi y send -X copy-pipe-and-cancel 'tmux save-buffer - | reattach-to-user-namespace pbcopy'; \
+    bind C-c run 'tmux save-buffer - | reattach-to-user-namespace pbcopy'; \
+    bind C-v run 'tmux set-buffer $(reattach-to-user-namespace pbpaste); tmux paste-buffer'" " \
+    bind-key -T copy-mode-vi y send -X copy-pipe-and-cancel 'xclip -selection clipboard -in'"
 
 ##############################
 ### Color & Style Settings ###


### PR DESCRIPTION
You could also add similar commands for C-c and C-v for Linux. I don't use those so didn't look into it. I haven't tested it on macs, I don't know if this will give an error with single quotes: `'tmux set-buffer $(reattach-to-user-namespace pbpaste); tmux paste-buffer'`