### PR TITLE
Add a Health Check Script

### DIFF
--- a/checkhealth.sh
+++ b/checkhealth.sh
@@ -1,13 +1,6 @@
 #!/usr/bin/env bash
 # Check the health of the dotfiles installation.
 
-# Things to check:
-# - [X] check key utilies are installed
-# - [X] check symlinks
-# - [ ] check XDG_CONFIG
-# - [ ] check shell
-# - [ ] check the path
-
 COLOR_GRAY="\033[1;38;5;243m"
 COLOR_BLUE="\033[1;34m"
 COLOR_GREEN="\033[1;32m"
@@ -20,7 +13,6 @@ newline=$'\n'
 color_print() {
     printf "%b%s%b" "$1" "$2" "$COLOR_NONE"
 }
-
 title() {
     echo -e "\n${COLOR_PURPLE}$1${COLOR_NONE}"
     echo -e "${COLOR_GRAY}==============================${COLOR_NONE}\n"
@@ -119,8 +111,25 @@ check_shell() {
     printf %s "$newline"
 }
 
+check_xdg_config() {
+    title "Checking XDG_CONFIG directory"
+    local xdg_config="$HOME/.config"
+
+    printf %s "Checking the existence of \"$xdg_config\"... "
+
+    if [[ -d "$xdg_config" ]]; then
+        success "Exists."
+    else
+        error "Missing.$newline$newline"
+        color_print "$COLOR_BLUE" "XDG_CONFIG directory is missing. Run \`./install.sh link\` to set up."
+    fi
+
+    printf %s "$newline"
+}
+
 title "Dotfiles health check"
 
 check_utils
 check_shell
 check_symlinks
+check_xdg_config

--- a/checkhealth.sh
+++ b/checkhealth.sh
@@ -17,22 +17,25 @@ COLOR_YELLOW="\033[1;33m"
 COLOR_NONE="\033[0m"
 newline=$'\n'
 
+color_print() {
+    printf "%b%s%b" "$1" "$2" "$COLOR_NONE"
+}
+
 title() {
     echo -e "\n${COLOR_PURPLE}$1${COLOR_NONE}"
     echo -e "${COLOR_GRAY}==============================${COLOR_NONE}\n"
 }
 
 error() {
-    echo -e "${COLOR_RED}Error: ${COLOR_NONE}$1"
-    exit 1
+    color_print "$COLOR_RED" "$*"
 }
 
 warning() {
-    printf "${COLOR_GREEN}" "$*" "${COLOR_NONE}"
+    color_print "$COLOR_YELLOW" "$*"
 }
 
 success() {
-    printf "${COLOR_GREEN}" "$*" "${COLOR_NONE}"
+    color_print "$COLOR_GREEN" "$*"
 }
 
 get_linkables() {
@@ -59,7 +62,7 @@ check_symlinks() {
 
     for link in $(get_linkables) ; do
         target="$HOME/.$(basename "$link" '.symlink')"
-        printf %s "Checking Symlink for \"$target\"... "
+        printf %s "Checking Symlink for \".$(basename "$link" ".symlink")\"... "
         if [[ -h "$target" ]]; then
             if [ "$link" != "$(readlink "$target")" ]; then
                 warn "$target is not properly symlinked"

--- a/checkhealth.sh
+++ b/checkhealth.sh
@@ -44,6 +44,7 @@ get_linkables() {
 
 check_utils() {
     local utils=(git brew tmux nvim kitty)
+    local missing_apps=0
     title "Checking for installed apps"
     for util in "${utils[@]}"; do
         printf %s "Checking $util... "
@@ -51,10 +52,16 @@ check_utils() {
         if test "$(command -v "$util")"; then
             success "Installed."
         else
-            warning "Not installed."
+            error "Not installed."
+            missing_apps=$((missing_apps+1))
         fi
         printf %s "$newline"
     done
+
+    if [ "$missing_apps" -gt 0 ]; then
+        error "${newline}Missing required utilities. Install them to continue."
+        exit 1
+    fi
 }
 
 check_symlinks() {
@@ -94,7 +101,26 @@ check_symlinks() {
     fi
 }
 
+check_shell() {
+    title "Checking shell"
+    local zsh_path
+
+    zsh_path="$(brew --prefix)/bin/zsh"
+
+    printf %s "Checking Shell: $SHELL... "
+
+    if [[ "$SHELL" = "$zsh_path" ]]; then 
+        success "Accepted.$newline" 
+    else
+        error "Rejected.$newline$newline"
+        color_print "$COLOR_BLUE" "Run \`./install.sh shell\` to setup the shell."
+    fi
+
+    printf %s "$newline"
+}
+
 title "Dotfiles health check"
 
 check_utils
+check_shell
 check_symlinks

--- a/checkhealth.sh
+++ b/checkhealth.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Check the health of the dotfiles installation.
+
+# Things to check:
+# - [ ] check symlinks
+# - [ ] check XDG_CONFIG
+# - [ ] check key utilies are installed
+# - [ ] check shell
+# - [ ] check the path
+
+COLOR_GRAY="\033[1;38;5;243m"
+COLOR_BLUE="\033[1;34m"
+COLOR_GREEN="\033[1;32m"
+COLOR_RED="\033[1;31m"
+COLOR_PURPLE="\033[1;35m"
+COLOR_YELLOW="\033[1;33m"
+COLOR_NONE="\033[0m"
+newline=$'\n'
+
+title() {
+    echo -e "\n${COLOR_PURPLE}$1${COLOR_NONE}"
+    echo -e "${COLOR_GRAY}==============================${COLOR_NONE}\n"
+}
+
+error() {
+    echo -e "${COLOR_RED}Error: ${COLOR_NONE}$1"
+    exit 1
+}
+
+warning() {
+    printf "${COLOR_GREEN}" "$*" "${COLOR_NONE}"
+}
+
+success() {
+    printf "${COLOR_GREEN}" "$*" "${COLOR_NONE}"
+}
+
+get_linkables() {
+    find -H "$DOTFILES" -maxdepth 3 -name '*.symlink'
+}
+
+check_utils() {
+    local utils=(git brew tmux nvim kitty)
+    title "Checking for installed apps"
+    for util in "${utils[@]}"; do
+        printf %s "Checking $util... "
+
+        if test "$(command -v "$util")"; then
+            success "Exists."
+        else
+            warning "MISSING. "
+        fi
+        printf %s "$newline"
+    done
+}
+
+check_symlinks() {
+    title "Checking Symlinks"
+
+    for link in $(get_linkables) ; do
+        target="$HOME/.$(basename "$link" '.symlink')"
+        printf %s "Checking Symlink for \"$target\"... "
+        if [[ -h "$target" ]]; then
+            if [ "$link" != "$(readlink "$target")" ]; then
+                warn "$target is not properly symlinked"
+            else
+                success "Exists."
+            fi
+        else
+            warn "$target symlink is missing."
+        fi
+        printf %s "$newline"
+    done
+}
+
+# title "Dotfiles health check"
+
+# check_utils
+check_symlinks


### PR DESCRIPTION
Add a script that can be run to check various points of the dotfiles installation to ensure things are set up correctly. This can help with debugging issues and installation verification.

**Checks**

- [x] Installed utilities
- [x] Shell
- [x] Symlinks
- [x] XDG_CONFIG
- [x] terminfo

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/293805/98419195-2415a880-204a-11eb-9c82-c24f16412b1f.png">

Fixes #157 