### PR TITLE
add(tmux): copy support for linux

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -6,6 +6,7 @@ if OS.mac?
     brew "mas"
     brew "noti"
     brew "trash"
+    brew "reattach-to-user-namespace"
 
     # Applications
     cask "kitty"
@@ -58,6 +59,8 @@ if OS.mac?
     mas "ColorSlurp", id: 1287239339
     mas "Bear", id: 1091189122
     mas "1Blocker", id: 1107421413
+elsif OS.linux?
+    brew "xclip"
 end
 
 tap "homebrew/bundle"

--- a/tmux/tmux.conf.symlink
+++ b/tmux/tmux.conf.symlink
@@ -83,12 +83,19 @@ unbind [
 bind Escape copy-mode
 unbind p
 bind p paste-buffer
-bind -Tcopy-mode-vi 'v' send -X begin-selection
-bind -Tcopy-mode-vi 'y' send -X copy-pipe-and-cancel "tmux save-buffer - | reattach-to-user-namespace pbcopy"
+bind -T copy-mode-vi v send -X begin-selection
 
-# Buffers to/from Mac clipboard, yay tmux book from pragprog
-bind C-c run "tmux save-buffer - | reattach-to-user-namespace pbcopy"
-bind C-v run "tmux set-buffer $(reattach-to-user-namespace pbpaste); tmux paste-buffer"
+if-shell "uname | grep -q Darwin" {
+    bind -T copy-mode-vi y send -X copy-pipe-and-cancel 'tmux save-buffer - | reattach-to-user-namespace pbcopy'; \
+    bind C-c run 'tmux save-buffer - | reattach-to-user-namespace pbcopy'; \
+    bind C-v run 'tmux set-buffer $(reattach-to-user-namespace pbpaste); tmux paste-buffer'
+}
+
+if-shell '[[ $(uname -s) = Linux ]]' {
+    bind -T copy-mode-vi y send -X copy-pipe-and-cancel 'xclip -i -sel clipboard'; \
+    bind C-c run "tmux save-buffer - | xclip -i -sel clipboard"; \
+    bind C-v run 'tmux set-buffer $(xclip -o -sel clipboard); tmux paste-buffer'
+}
 
 ##############################
 ### Color & Style Settings ###


### PR DESCRIPTION
As I couldn't test in mac I've left your commands the same but you can see [here](https://github.com/tmux-plugins/tmux-sensible/issues/42) that there's no longer a need for reattach-to-user-namespace. You have to test if it works just with pbcopy alone.

An useful addition that I haven't included is that selection with mouse should copy to clipboard right away, in addition to the default action. In linux it's done with:
```
bind -T copy-mode-vi v send -X begin-selection

if-shell 'uname | grep -q Darwin' {
    bind C-c run 'tmux save-buffer - | reattach-to-user-namespace pbcopy'; \
    bind C-v run 'tmux set-buffer $(reattach-to-user-namespace pbpaste); tmux paste-buffer'
    bind -T copy-mode-vi y send -X copy-pipe-and-cancel 'tmux save-buffer - | reattach-to-user-namespace pbcopy'; \
    bind -T copy-mode-vi C-v send -X rectangle-toggle \; send -X begin-selection; \

    # Selection with mouse should copy to clipboard right away, in addition to the default action.
    unbind -n -T copy-mode-vi MouseDragEnd1Pane; \
    bind -T copy-mode-vi MouseDragEnd1Pane send -X copy-selection-and-cancel\; run 'tmux save-buffer - | reattach-to-user-namespace pbcopy > /dev/null'; \

    # Middle click to paste from the clipboard
    unbind MouseDown2Pane; \
    bind -n MouseDown2Pane run 'tmux set-buffer $(reattach-to-user-namespace pbpaste); tmux paste-buffer'
}

if-shell '[[ $(uname -s) = Linux ]]' {
    bind C-c run "tmux save-buffer - | xclip -selection clipboard -in"; \
    bind C-v run 'tmux set-buffer $(xclip -selection clipboard -out); tmux paste-buffer'; \
    bind -T copy-mode-vi y send -X copy-pipe-and-cancel 'xclip -selection clipboard -in'; \
    bind -T copy-mode-vi C-v send -X rectangle-toggle \; send -X begin-selection; \

\   # Selection with mouse should copy to clipboard right away, in addition to the default action.
    unbind -n -T copy-mode-vi MouseDragEnd1Pane; \
    bind -T copy-mode-vi MouseDragEnd1Pane send -X copy-selection-and-cancel\; run 'tmux save-buffer - | xclip -selection clipboard -in > /dev/null'; \

    # Middle click to paste from the clipboard
    unbind MouseDown2Pane; \
    bind -n MouseDown2Pane run 'tmux set-buffer $(xclip -o -sel clipboard); tmux paste-buffer'
}
```