### PR TITLE
Fix vimux command being called like a function

### DIFF
--- a/config/nvim/ftplugin/javascript.vim
+++ b/config/nvim/ftplugin/javascript.vim
@@ -3,4 +3,4 @@ let g:javascript_plugin_jsdoc = 1
 
 let javaScript_fold=1
 
-nmap <leader>x :VimuxRunCommand('npm test')<cr>
+nmap <leader>x :call VimuxRunCommand('npm test')<cr>

--- a/config/nvim/ftplugin/typescript.vim
+++ b/config/nvim/ftplugin/typescript.vim
@@ -7,4 +7,4 @@ nmap <silent> <leader>h :TSType<cr>
 
 setl omnifunc=TSOmnicFunc
 
-nmap <leader>x :VimuxRunCommand('npm test')<cr>
+nmap <leader>x :call VimuxRunCommand('npm test')<cr>


### PR DESCRIPTION
This only worked by accident, but a proper function with the same name is also available, so call that properly.