### PR TITLE
Using built-in wezterm "multiplexing" as tmux replacement

### DIFF
--- a/config/nvim/lua/nisi/config/keymaps.lua
+++ b/config/nvim/lua/nisi/config/keymaps.lua
@@ -69,10 +69,10 @@ vmap(">", ">gv")
 vmap(".", ":normal .<cr>") -- run `.` command in visual mode
 
 -- Move between panes or create new panes
-nmap("<C-h>", "<Plug>WinMoveLeft")
-nmap("<C-j>", "<Plug>WinMoveDown")
-nmap("<C-k>", "<Plug>WinMoveUp")
-nmap("<C-l>", "<Plug>WinMoveRight")
+-- nmap("<C-h>", "<Plug>WinMoveLeft")
+-- nmap("<C-j>", "<Plug>WinMoveDown")
+-- nmap("<C-k>", "<Plug>WinMoveUp")
+-- nmap("<C-l>", "<Plug>WinMoveRight")
 
 -- move line mappings
 local opt_h = "˙"

--- a/config/nvim/lua/nisi/init.lua
+++ b/config/nvim/lua/nisi/init.lua
@@ -160,6 +160,104 @@ function M.setup(user_config)
   require("nisi.config.keymaps")
   init_plugins()
 
+  -- @TODO seems like it's not the right place for smart-splits setup, but it has to be after init_plugins
+  require("smart-splits").setup({
+    -- Ignored buffer types (only while resizing)
+    ignored_buftypes = {
+      "nofile",
+      "quickfix",
+      "prompt",
+    },
+    -- Ignored filetypes (only while resizing)
+    ignored_filetypes = { "NvimTree" },
+    -- the default number of lines/columns to resize by at a time
+    default_amount = 3,
+    -- Desired behavior when your cursor is at an edge and you
+    -- are moving towards that same edge:
+    -- 'wrap' => Wrap to opposite side
+    -- 'split' => Create a new split in the desired direction
+    -- 'stop' => Do nothing
+    -- function => You handle the behavior yourself
+    -- NOTE: If using a function, the function will be called with
+    -- a context object with the following fields:
+    -- {
+    --    mux = {
+    --      type:'tmux'|'wezterm'|'kitty'
+    --      current_pane_id():number,
+    --      is_in_session(): boolean
+    --      current_pane_is_zoomed():boolean,
+    --      -- following methods return a boolean to indicate success or failure
+    --      current_pane_at_edge(direction:'left'|'right'|'up'|'down'):boolean
+    --      next_pane(direction:'left'|'right'|'up'|'down'):boolean
+    --      resize_pane(direction:'left'|'right'|'up'|'down'):boolean
+    --      split_pane(direction:'left'|'right'|'up'|'down',size:number|nil):boolean
+    --    },
+    --    direction = 'left'|'right'|'up'|'down',
+    --    split(), -- utility function to split current Neovim pane in the current direction
+    --    wrap(), -- utility function to wrap to opposite Neovim pane
+    -- }
+    -- NOTE: `at_edge = 'wrap'` is not supported on Kitty terminal
+    -- multiplexer, as there is no way to determine layout via the CLI
+    at_edge = "split",
+    -- Desired behavior when the current window is floating:
+    -- 'previous' => Focus previous Vim window and perform action
+    -- 'mux' => Always forward action to multiplexer
+    float_win_behavior = "previous",
+    -- when moving cursor between splits left or right,
+    -- place the cursor on the same row of the *screen*
+    -- regardless of line numbers. False by default.
+    -- Can be overridden via function parameter, see Usage.
+    move_cursor_same_row = false,
+    -- whether the cursor should follow the buffer when swapping
+    -- buffers by default; it can also be controlled by passing
+    -- `{ move_cursor = true }` or `{ move_cursor = false }`
+    -- when calling the Lua function.
+    cursor_follows_swapped_bufs = false,
+    -- resize mode options
+    resize_mode = {
+      -- key to exit persistent resize mode
+      quit_key = "<ESC>",
+      -- keys to use for moving in resize mode
+      -- in order of left, down, up' right
+      resize_keys = { "h", "j", "k", "l" },
+      -- set to true to silence the notifications
+      -- when entering/exiting persistent resize mode
+      silent = false,
+      -- must be functions, they will be executed when
+      -- entering or exiting the resize mode
+      hooks = {
+        on_enter = nil,
+        on_leave = nil,
+      },
+    },
+    -- ignore these autocmd events (via :h eventignore) while processing
+    -- smart-splits.nvim computations, which involve visiting different
+    -- buffers and windows. These events will be ignored during processing,
+    -- and un-ignored on completed. This only applies to resize events,
+    -- not cursor movement events.
+    ignored_events = {
+      "BufEnter",
+      "WinEnter",
+    },
+    -- enable or disable a multiplexer integration;
+    -- automatically determined, unless explicitly disabled or set,
+    -- by checking the $TERM_PROGRAM environment variable,
+    -- and the $KITTY_LISTEN_ON environment variable for Kitty
+    multiplexer_integration = nil,
+    -- disable multiplexer navigation if current multiplexer pane is zoomed
+    -- this functionality is only supported on tmux and Wezterm due to kitty
+    -- not having a way to check if a pane is zoomed
+    disable_multiplexer_nav_when_zoomed = true,
+    -- default logging level, one of: 'trace'|'debug'|'info'|'warn'|'error'|'fatal'
+    log_level = "info",
+  })
+
+  vim.keymap.set("n", "<C-h>", require("smart-splits").move_cursor_left)
+  vim.keymap.set("n", "<C-j>", require("smart-splits").move_cursor_down)
+  vim.keymap.set("n", "<C-k>", require("smart-splits").move_cursor_up)
+  vim.keymap.set("n", "<C-l>", require("smart-splits").move_cursor_right)
+  vim.keymap.set("n", "<C-\\>", require("smart-splits").move_cursor_previous)
+
   -- do these sctions after initializing the plugins
   apply_colorscheme(config.colorscheme)
   vim.cmd.syntax("on")

--- a/config/nvim/lua/nisi/plugins/core.lua
+++ b/config/nvim/lua/nisi/plugins/core.lua
@@ -5,6 +5,7 @@ return {
   "tpope/vim-repeat",
   "tpope/vim-sleuth",
   "editorconfig/editorconfig-vim", -- TODO is this still required?
+  "mrjones2014/smart-splits.nvim",
   {
     "andymass/vim-matchup",
     cond = not vim.g.vscode,

--- a/config/wezterm/wezterm.lua
+++ b/config/wezterm/wezterm.lua
@@ -18,7 +18,9 @@ config.colors = {
 }
 
 config.macos_window_background_blur = 30
-config.enable_tab_bar = false
+config.enable_tab_bar = true
+config.hide_tab_bar_if_only_one_tab = true
+config.use_fancy_tab_bar = false
 config.window_decorations = "RESIZE"
 config.window_close_confirmation = "NeverPrompt"
 config.native_macos_fullscreen_mode = true


### PR DESCRIPTION
#233

Not sure about the terminology. It seems like multiplexing, but if you search wezterm docs, it mostly talks about [unix domain sockets](https://wezfurlong.org/wezterm/multiplexing.html#ssh-domains). Which would be nice for closing the terminal without loosing the state, but it comes at a high cost.

However, most of the things I use tmux for can be done with the tools that wezterm has built-in. It removes the tmux layer, and makes everything more snappy.

## Creating split panes and switching between them, zooming:

https://github.com/user-attachments/assets/6542aaf0-d9ac-4761-bc0a-cbebfd3b5d44

## Creating new tabs and navigating between them

https://github.com/user-attachments/assets/e9d53a7b-6b3a-4324-8ec1-5e414aa1bc57

## Workspaces (sessions)
Alternative is to use https://github.com/MLFlexer/smart_workspace_switcher.wezterm
https://github.com/user-attachments/assets/78d0518a-9531-4de9-9663-afb8f14016ca

## Lazygit

Switches to wrong workspace after closing. Can be improved. 

https://github.com/user-attachments/assets/e39248da-ead2-4fd8-8b8b-b298efbf27c7

## Copy mode


https://github.com/user-attachments/assets/cdeeb256-d862-449c-89a6-a4196869d703

