### PR TITLE
fix(zsh): zfetch array expansion + guard vite-plus env source

### DIFF
--- a/config/zsh/.zsh_functions
+++ b/config/zsh/.zsh_functions
@@ -79,10 +79,9 @@ case $1 in
       echo -e "Missing plugin ${Yel}${name}${Rst}"
       echo -e "  Cloning from ${Blu}${url}${Rst}..."
 
-      local clone_cmd="git clone --quiet"
-      [[ -z $ref ]] && clone_cmd+=" --depth 1"
-
-      if $clone_cmd $url $dest; then
+      local clone_cmd=(git clone --quiet)
+      [[ -z $ref ]] && clone_cmd+=(--depth 1)
+      if "${clone_cmd[@]}" $url $dest; then
         if [[ -n $ref ]]; then
           (cd $dest && git checkout --quiet $ref)
           echo -e "  Checked out branch ${ref}"

--- a/config/zsh/.zsh_functions
+++ b/config/zsh/.zsh_functions
@@ -81,9 +81,9 @@ case $1 in
 
       local clone_cmd=(git clone --quiet)
       [[ -z $ref ]] && clone_cmd+=(--depth 1)
-      if "${clone_cmd[@]}" $url $dest; then
+      if "${clone_cmd[@]}" "$url" "$dest"; then
         if [[ -n $ref ]]; then
-          (cd $dest && git checkout --quiet $ref)
+          (cd "$dest" && git checkout --quiet "$ref")
           echo -e "  Checked out branch ${ref}"
         else
           echo -e "  Checked out default branch"

--- a/config/zsh/.zshrc
+++ b/config/zsh/.zshrc
@@ -169,4 +169,4 @@ fi
 [[ -x "$HOME/.local/bin/mise" ]] && eval "$(~/.local/bin/mise activate zsh)"
 
 # Vite+ bin (https://viteplus.dev)
-. "$HOME/.vite-plus/env"
+[[ -f "$HOME/.vite-plus/env" ]] && . "$HOME/.vite-plus/env"


### PR DESCRIPTION
## Summary

Two small zsh fixes found while setting up the dotfiles on a fresh machine:

- **zfetch array expansion** (`config/zsh/.zsh_functions`): the `git clone` command was built as a string and re-expanded, which breaks under zsh word-splitting rules. Switched to an array and expanded with `"${clone_cmd[@]}"`.
- **vite-plus guard** (`config/zsh/.zshrc`): sourcing `~/.vite-plus/env` unconditionally fails on machines without vite-plus installed. Wrapped it with `[[ -f ... ]] &&` to match the style used elsewhere in the file (mise, pyenv, pnpm, etc.).

Two commits so they can be reverted independently if needed.

## Test plan

- [x] Fresh zsh session loads without errors on a machine without vite-plus
- [x] zfetch successfully clones plugins (verified with zsh-syntax-highlighting, zsh-autosuggestions, etc.)
- [ ] Nick to confirm vite-plus still loads on his machine (file exists → guard passes)