### PR TITLE
fix(theme-set): show wallpaper previews inside tmux

### DIFF
--- a/bin/theme-set
+++ b/bin/theme-set
@@ -76,12 +76,18 @@ preview_theme() { # fzf --preview for theme names
   printf '\033[2m%s wallpaper%s\033[0m\n' "$n" "$([ "$n" = 1 ] && printf '' || printf 's')"
 }
 
+kitty_graphics() { # kitty protocol usable: direct, or through tmux passthrough
+  case "${TERM_PROGRAM:-}" in ghostty | kitty) return 0 ;; esac
+  case "$(tmux display -p '#{client_termname}' 2>/dev/null)" in *ghostty* | *kitty*) return 0 ;; esac
+  return 1
+}
+
 preview_bg() { # fzf --preview for a theme's Nth wallpaper
   local img; img="$(ls "$THEMES_DIR/$1"/backgrounds/* 2>/dev/null | sed -n "$2p")"
   [ -n "$img" ] || exit 0
   printf '\033[1m%s\033[0m\n' "$(basename "$img")"
   local kitten=/Applications/kitty.app/Contents/MacOS/kitten
-  if [ -x "$kitten" ] && [ "${TERM_PROGRAM:-}" = ghostty -o "${TERM_PROGRAM:-}" = kitty ]; then
+  if [ -x "$kitten" ] && kitty_graphics; then
     # kitty graphics protocol (ghostty speaks it); must bypass fzf's capture
     "$kitten" icat --clear --transfer-mode=memory --stdin=no --scale-up \
       --place "${FZF_PREVIEW_COLUMNS:-80}x$(( ${FZF_PREVIEW_ROWS:-20} - 2 ))@0x2" "$img" >/dev/tty 2>/dev/null || true


### PR DESCRIPTION
`theme-set`'s wallpaper picker never showed real images inside tmux: `preview_bg` gated on `TERM_PROGRAM=ghostty|kitty`, but tmux sets `TERM_PROGRAM=tmux`, so it always fell back to `img2txt` ASCII.

Add `kitty_graphics()`: check `TERM_PROGRAM` first, then `tmux display -p '#{client_termname}'` (e.g. `xterm-ghostty`). `kitten icat` (0.39) is tmux-aware and renders through `allow-passthrough` (already enabled in tmux.conf); verified end-to-end with a raw kitty-protocol image inside tmux.